### PR TITLE
fix: E on "Neovimの設定はinit.lua" stops at "の" or "は"

### DIFF
--- a/lua/budouxify/motion.lua
+++ b/lua/budouxify/motion.lua
@@ -237,16 +237,15 @@ function M._find_forward(opts)
 	local n = #leftchars - #leftchars_utf8
 	for i, segment in pairs(segments) do
 		n = n + #segment
-		if n > col then
-			if opts.head then
-				if i == #segments and not pos_next_ascii then
-					return M._find_forward_in_next_line(opts.buf, row, opts.head)
-				end
-				return { row = row, col = n }
-			else
-				local x, y = vim.regex(".$"):match_str(string.sub(curline, 1, n))
-				return { row = row, col = n - y + x }
+		if opts.head and n > col then
+			if i == #segments and not pos_next_ascii then
+				return M._find_forward_in_next_line(opts.buf, row, opts.head)
 			end
+			return { row = row, col = n }
+		elseif n > col + 3 then
+			-- TODO: マジックナンバーきもちわるい
+			local x, y = vim.regex(".$"):match_str(string.sub(curline, 1, n))
+			return { row = row, col = n - y + x }
 		end
 	end
 

--- a/tests/budouxify/test_motion.lua
+++ b/tests/budouxify/test_motion.lua
@@ -211,6 +211,10 @@ local parameters_list = {
 			"　　＾W  E",
 			"今日はGOOD",
 		} },
+		{ {
+			"      ＾Ｗ　Ｅ",
+			"Neovimの設定はinit.lua",
+		} },
 	},
 }
 


### PR DESCRIPTION
```
Fails (1) and Notes (0)
FAIL in tests/budouxify/test_motion.lua | Cursor on non-ASCII WORD | E + args { { "      ＾Ｗ　Ｅ", "Neovimの設定はinit.lua" } }: ...ithub.com/google/budouxify.nvim/lua/budouxify/motion.lua:77: Unexpected case: cursor is not moved
  Traceback:
    ...ithub.com/google/budouxify.nvim/lua/budouxify/motion.lua:77
    tests/budouxify/test_motion.lua:261
```